### PR TITLE
Edits to high/low address references for LIS3MDL

### DIFF
--- a/lis3mdl.h
+++ b/lis3mdl.h
@@ -12,8 +12,8 @@ namespace lis3mdl
 
   enum i2c_addr
   {
-    SA1_LOW_ADDR = 0x1E,
-    SA1_HIGH_ADDR = 0x1C,
+    SA1_LOW_ADDR = 0x1C,
+    SA1_HIGH_ADDR = 0x1E,
   };
 
   enum reg_addr

--- a/minimu9.cpp
+++ b/minimu9.cpp
@@ -31,7 +31,7 @@ minimu9::comm_config minimu9::auto_detect(const std::string & i2c_bus_name)
 
   // Detect LIS3MDL devices.
   {
-    auto addrs = { lis3mdl::SA1_LOW_ADDR, lis3mdl::SA1_LOW_ADDR };
+    auto addrs = { lis3mdl::SA1_LOW_ADDR, lis3mdl::SA1_HIGH_ADDR };
     for (uint8_t addr : addrs)
     {
       int result = bus.try_write_byte_and_read_byte(addr, lis3mdl::WHO_AM_I);


### PR DESCRIPTION
Hello minimu9-ahrs developers, 

In general I have found this to be tremendously helpful software.  I'm just proposing two very small edits to fix what I think might be errors (but apologies in advance if I am wrong). 

In lis3mdl.h: The high and low addresses appeared to be swapped, when compared to the table on the MinIMU-9 v5 product page.

In minimu9.cpp: It appeared that this was searching for the low lis3mdl address twice, rather than for both the low and high address.

-Karin



