### PR TITLE
Fixed build on more recent distros by including headers

### DIFF
--- a/i2c_bus.cpp
+++ b/i2c_bus.cpp
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <linux/i2c-dev.h>
+#include <linux/i2c.h>
 
 static inline std::system_error posix_error(const std::string & what)
 {

--- a/i2c_bus.h
+++ b/i2c_bus.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <sys/ioctl.h>
 
 class i2c_bus
 {


### PR DESCRIPTION
I fixed the build on more recent distros (in my case Raspbian Buster specifically). It would be great if this could be merged so that I can use your upstream repo instead of using this fork in my build scripts.